### PR TITLE
Amend secret name to match secret in Kubernetes

### DIFF
--- a/helm_deploy/hmpps-arns-assessment-platform-api/values.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-api/values.yaml
@@ -29,8 +29,8 @@ generic-service:
     hmpps-arns-assessment-platform-api-application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
     hmpps-arns-assessment-platform-api-client-creds:
-      CLIENT_CREDS_CLIENT_ID: 'API_CLIENT_ID'
-      CLIENT_CREDS_CLIENT_SECRET: 'API_CLIENT_SECRET'
+      API_CLIENT_ID: 'API_CLIENT_ID'
+      API_CLIENT_SECRET: 'API_CLIENT_SECRET'
 
   allowlist:
     groups:


### PR DESCRIPTION
The secret name in the values does not match the one in the secrets.

This fix will allow deployment to work.