### PR TITLE
ARN-3118: Switch offset pagination for cursor pattern

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/persistence/repository/EventRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/persistence/repository/EventRepository.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.persistence.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Limit
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -18,17 +17,24 @@ interface EventRepository : JpaRepository<EventEntity<*>, Long> {
   fun findTopByAssessmentUuidOrderByPositionDesc(assessmentUuid: UUID): EventEntity<*>?
   fun findAllByAssessmentUuidAndCreatedAtGreaterThanEqual(assessmentUuid: UUID, from: LocalDateTime): List<EventEntity<*>>
 
+  // Cursor pattern used over normal offset pagination because paginating
+  // over large result sets take long enough for the underlying data to
+  // change, and offset pagination can drop rows when that happens.
   @Query(
     """
-    SELECT DISTINCT e.assessment FROM EventEntity e
-    WHERE e.assessment.type = :assessmentType
-    AND e.createdAt > :since
-    AND e.deleted IS FALSE
+    SELECT DISTINCT a FROM EventEntity e
+    JOIN e.assessment a
+    WHERE a.type = :assessmentType
+      AND e.createdAt > :since
+      AND e.deleted IS FALSE
+      AND (:after IS NULL OR a.uuid > :after)
+    ORDER BY a.uuid
     """,
   )
-  fun findAssessmentsModifiedSince(
+  fun findAssessmentsModifiedSinceAfter(
     assessmentType: String,
     since: LocalDateTime,
-    pageable: Pageable,
-  ): Page<AssessmentEntity>
+    after: UUID?,
+    limit: Limit,
+  ): List<AssessmentEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/GetAssessmentsModifiedSinceQuery.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/GetAssessmentsModifiedSinceQuery.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query
 
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.common.UserDetails
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GetAssessmentsModifiedSinceQuery(
   override val user: UserDetails,
   val assessmentType: String,
   val since: LocalDateTime,
-  override val pageNumber: Int = 0,
-  override val pageSize: Int = 50,
+  val after: UUID? = null,
+  val limit: Int = 50,
   override val timestamp: LocalDateTime? = null,
-) : RequestableQuery,
-  PageableQuery
+) : RequestableQuery

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/handler/GetAssessmentsModifiedSinceQueryHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/handler/GetAssessmentsModifiedSinceQueryHandler.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.handler
 
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Limit
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.aggregate.assessment.AssessmentAggregate
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.aggregate.assessment.AssessmentState
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.persistence.reposi
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.GetAssessmentsModifiedSinceQuery
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.result.AssessmentVersionQueryResult
 import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.result.GetAssessmentsModifiedSinceQueryResult
-import uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.result.PageInfo
 
 @Component
 class GetAssessmentsModifiedSinceQueryHandler(
@@ -26,20 +25,20 @@ class GetAssessmentsModifiedSinceQueryHandler(
   override fun handle(query: GetAssessmentsModifiedSinceQuery): GetAssessmentsModifiedSinceQueryResult {
     validateMaxLookback(query)
 
-    val page = eventRepository.findAssessmentsModifiedSince(
-      query.assessmentType,
-      query.since,
-      PageRequest.of(query.pageNumber, query.pageSize),
+    val assessments = eventRepository.findAssessmentsModifiedSinceAfter(
+      assessmentType = query.assessmentType,
+      since = query.since,
+      after = query.after,
+      limit = Limit.of(query.limit),
     )
 
-    val assessments = page.content.map { assessment -> buildResult(assessment) }
+    val results = assessments.map(::buildResult)
+
+    val nextCursor = if (assessments.size == query.limit) assessments.last().uuid else null
 
     return GetAssessmentsModifiedSinceQueryResult(
-      assessments = assessments,
-      pageInfo = PageInfo(
-        pageNumber = page.number,
-        totalPages = page.totalPages,
-      ),
+      assessments = results,
+      nextCursor = nextCursor,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/result/GetAssessmentsModifiedSinceQueryResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/query/result/GetAssessmentsModifiedSinceQueryResult.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.arnsassessmentplatformapi.query.result
 
+import java.util.UUID
+
 data class GetAssessmentsModifiedSinceQueryResult(
   val assessments: List<AssessmentVersionQueryResult>,
-  override val pageInfo: PageInfo,
-) : QueryResult,
-  PageableQueryResult
+  val nextCursor: UUID?,
+) : QueryResult

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/controller/assessment/query/GetAssessmentsModifiedSinceQueryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/arnsassessmentplatformapi/controller/assessment/query/GetAssessmentsModifiedSinceQueryTest.kt
@@ -64,10 +64,11 @@ class GetAssessmentsModifiedSinceQueryTest(
     assertThat(result.assessments).hasSize(2)
     assertThat(result.assessments.map { it.assessmentUuid })
       .containsExactlyInAnyOrder(newAssessment1.uuid, newAssessment2.uuid)
+    assertThat(result.nextCursor).isNull()
   }
 
   @Test
-  fun `it paginates results and all pages contain all data`() {
+  fun `cursor paging walks all assessments across pages`() {
     userDetailsRepository.save(testUserDetailsEntity)
     val type = "PAGINATE_${UUID.randomUUID()}"
 
@@ -78,8 +79,7 @@ class GetAssessmentsModifiedSinceQueryTest(
     }
 
     val allAssessmentUuids = mutableSetOf<UUID>()
-    var pageNumber = 0
-    var totalPages: Int
+    var cursor: UUID? = null
 
     do {
       val request = QueriesRequest(
@@ -88,8 +88,8 @@ class GetAssessmentsModifiedSinceQueryTest(
             user = testUserDetails,
             assessmentType = type,
             since = since,
-            pageSize = 2,
-            pageNumber = pageNumber,
+            after = cursor,
+            limit = 2,
           ),
         ),
       )
@@ -105,13 +105,10 @@ class GetAssessmentsModifiedSinceQueryTest(
         .responseBody
 
       val result = assertIs<GetAssessmentsModifiedSinceQueryResult>(response?.queries?.get(0)?.result)
-      totalPages = result.pageInfo.totalPages
-      assertThat(result.pageInfo.pageNumber).isEqualTo(pageNumber)
       allAssessmentUuids.addAll(result.assessments.map { it.assessmentUuid })
-      pageNumber++
-    } while (pageNumber < totalPages)
+      cursor = result.nextCursor
+    } while (cursor != null)
 
-    assertThat(totalPages).isEqualTo(3)
     assertThat(allAssessmentUuids).containsExactlyInAnyOrderElementsOf(created.map { it.uuid })
   }
 
@@ -144,6 +141,7 @@ class GetAssessmentsModifiedSinceQueryTest(
 
     val result = assertIs<GetAssessmentsModifiedSinceQueryResult>(response?.queries?.get(0)?.result)
     assertThat(result.assessments).isEmpty()
+    assertThat(result.nextCursor).isNull()
   }
 
   private fun createAssessmentWithEvent(type: String, eventCreatedAt: LocalDateTime): AssessmentEntity {


### PR DESCRIPTION
Switched `GetAssessmentsModifiedSinceQuery` from offset pagination to a cursor pagination. Offset pagination silently drops rows when the data changes, such as mid query inserts, which can push records across page boundaries that have already been crossed. The mid query insert record will end up being captured, but the record(s) it bumped out of the page wont be, even on subsequent calls to `GetAssessmentsModifiedSinceQuery`