### PR TITLE
Limit lookback

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,7 +19,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    QUERY_MAX_LOOKBACK_DAYS: 7
+    QUERY_MAX_LOOKBACK_DAYS: 0
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,7 +8,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    QUERY_MAX_LOOKBACK_DAYS: 0
+    QUERY_MAX_LOOKBACK_DAYS: 7
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,7 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    QUERY_MAX_LOOKBACK_DAYS: 0
+    QUERY_MAX_LOOKBACK_DAYS: 7
 
   autoscaling:
     enabled: false

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -19,7 +19,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    QUERY_MAX_LOOKBACK_DAYS: 0
+    QUERY_MAX_LOOKBACK_DAYS: 7
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -19,7 +19,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    QUERY_MAX_LOOKBACK_DAYS: 7
+    QUERY_MAX_LOOKBACK_DAYS: 0
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
- Limits lookback to 7 days for "GetAssessmentsModifiedSince" query for prod and preprod environments.
- Prevents clients from requesting assessments that have been modified over 7 days ago.
- Lookback env var in place to stop clients erroneously or maliciously dumping large quantities of assessment data.
- 0 value allows clients to request assessments without limit (i.e. all assessments).
