### PR TITLE
Enable ModSec WAF: blocking in dev/test, DetectionOnly in preprod/prod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,7 +6,7 @@ generic-service:
     host: arns-assessment-platform-api-dev.hmpps.service.justice.gov.uk
     modsecurity_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,17 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-api-preprod.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,6 +6,17 @@ generic-service:
 
   ingress:
     host: arns-assessment-platform-api.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -6,7 +6,7 @@ generic-service:
     host: arns-assessment-platform-api-test.hmpps.service.justice.gov.uk
     modsecurity_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives


### PR DESCRIPTION
Final WAF test configuration for the ARNS Assessment Platform API.

Last test of the existing WAF ruleset with enforcement enabled in dev and test, and DetectionOnly (log-only) in preprod/prod to gather data against production-like traffic before enabling enforcement there.

