### PR TITLE
Cronjob that restarts the API pods after the DB refresh job has run 

### DIFF
--- a/helm_deploy/hmpps-arns-assessment-platform-api/templates/preprod-rollout-restart.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-api/templates/preprod-rollout-restart.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.global.environment "preprod" -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: aap-api-rollout-restart
+spec:
+  schedule: "30 8 * * 0" # 8:30AM on Sunday, after the DB refresh job has run
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: restart-deployment
+          restartPolicy: OnFailure
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  kubectl rollout restart deployment/hmpps-arns-assessment-platform-api \
+                    -n {{ .Release.Namespace }}
+{{- end }}

--- a/helm_deploy/hmpps-arns-assessment-platform-api/templates/prod-to-preprod-refresh-job.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-api/templates/prod-to-preprod-refresh-job.yaml
@@ -26,9 +26,9 @@ metadata:
 spec:
   schedule: "0 8 * * 0"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 3600
       backoffLimit: 0
       activeDeadlineSeconds: 1200
       template:


### PR DESCRIPTION
INSERTs are failing after the DB refresh job loads in new data from prod, because DB sequences are kept in memory in the pods. This cronjob will restart the API pods 30 mins after the DB refresh job has run each Sunday.