### PR TITLE
Reintroduce ModSec: pin ingress classes (modsec/modsec-non-prod), add SecAuditEngine On for DetectionOnly

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,7 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-api-dev.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine On

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,8 +4,12 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-api-preprod.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_snippet: |
+      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
+      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
+      SecAuditEngine On
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,6 +6,21 @@ generic-service:
 
   ingress:
     host: arns-assessment-platform-api.hmpps.service.justice.gov.uk
+    className: modsec
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
+      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -4,6 +4,7 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-api-test.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine On


### PR DESCRIPTION
Re-enables ModSecurity on the AAP API and makes the ingress-class selection explicit across all environments:

Previous attempts to enable ModSec on the prod API caused outages. We think the root cause is enabling modsecurity_enabled silently switches the ingress from the default class to the modsec class, a separate controller behind a different load balancer. The Coordinator API calls us via the external hostname and held a stale cached route, so its requests hit the old controller and got default-backend 404s (not a ModSec block). This change makes the class choice explicit and deliberate so the switch is intentional.

- Pinned ingress classes per the Cloud Platform ModSecurity handbook: modsec for production, modsec-non-prod for non-production (t[he handbook separates these for performance, stability and staged rule-upgrade,](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#what-is-a-web-application-firewall-waf)  previously non-prod was incorrectly on the prod modsec class).
 - Added SecAuditEngine On to the DetectionOnly environments (prod, preprod). [Per the handbook](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#what-is-a-web-application-firewall-waf), audit defaults to RelevantOnly in DetectionOnly mode, so this is required to get full request visibility in OpenSearch while we monitor the rollout.