### PR TITLE
Add ModSec rule exclusions for confirmed false positives

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,8 +10,12 @@ generic-service:
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # User text and login tokens sent to /command and /query trigger false blocks; skip those checks here only.
+      SecRule REQUEST_URI "@rx ^/(command|query)(\?|$)" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS,ctl:ruleRemoveTargetByTag=attack-lfi;ARGS"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT etc..
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT DELETE"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,14 +7,17 @@ generic-service:
     className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_snippet: |
-      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
-      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
+      # Full audit logging for the DetectionOnly rollout (default RelevantOnly omits passed requests).
       SecAuditEngine On
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # User text and login tokens sent to /command and /query trigger false blocks; skip those checks here only.
+      SecRule REQUEST_URI "@rx ^/(command|query)(\?|$)" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS,ctl:ruleRemoveTargetByTag=attack-lfi;ARGS"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT etc..
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT DELETE"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,14 +9,17 @@ generic-service:
     className: modsec
     modsecurity_enabled: true
     modsecurity_snippet: |
-      # Required for DetectionOnly: default audit logging is RelevantOnly (warnings/errors only);
-      # SecAuditEngine On gives full request visibility in OpenSearch while we monitor the rollout.
+      # Full audit logging for the DetectionOnly rollout (default RelevantOnly omits passed requests).
       SecAuditEngine On
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # User text and login tokens sent to /command and /query trigger false blocks; skip those checks here only.
+      SecRule REQUEST_URI "@rx ^/(command|query)(\?|$)" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS,ctl:ruleRemoveTargetByTag=attack-lfi;ARGS"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT etc..
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT DELETE"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -10,8 +10,12 @@ generic-service:
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # User text and login tokens sent to /command and /query trigger false blocks; skip those checks here only.
+      SecRule REQUEST_URI "@rx ^/(command|query)(\?|$)" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS,ctl:ruleRemoveTargetByTag=attack-lfi;ARGS"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT etc..
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT DELETE"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
Adds narrowly-scoped ModSecurity rule exclusions to all four environments.

Every false positive found in the logs was **legitimate traffic** that the OWASP CRS rules misread as an attack. Left unfixed, these would block real requests once we switch from DetectionOnly to blocking:

 - 920272 "!REQUEST_BODY" - excludes the raw request body from one strict character-check rule that false-alarms on normal JSON/form content; the rule still applies to the URI, headers and args.
 - /command + /query ARGS exclusion - switches off the RCE, SQLi, PHP, generic-injection and LFI rule families for the request args on just these two endpoints, where practitioner free-text and the handover JWT coincidentally match attack patterns; everything else stays scanned.
- tx.allowed_methods (900200) - adds PUT and DELETE to the methods CRS rule 911100 permits, so the API's legitimate DELETE/PUT calls aren't blocked as method violations
