### PR TITLE
Replace template README with project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,28 +73,10 @@ docker compose -f docker/docker-compose.base.yml up postgres redis hmpps-auth lo
 
 ### Common Development Commands
 
+View the full list of development commands and their use by running:
+
 ```bash
-# Testing
-make test                         # Run all tests
-make test-targeted TESTS="*Test"  # Run specific tests
-
-# Code Quality
-make lint                         # Run ktlint
-make lint-fix                     # Auto-fix linting issues
-
-# Container Management
-make down                         # Stop all containers
-make clean                        # Clean containers, volumes, and build dirs
-make update                       # Update container images
-
-# Database (requires active kubectl context)
-make db-port-forward-pod          # Create port-forwarding pod
-make db-port-forward              # Forward local port 5434 to remote DB
-make db-connect                   # Connect to remote DB via psql
-
-# TypeScript Client
-make build-client                 # Generate TypeScript client from OpenAPI spec
-```
+make
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![repo standards badge](https://img.shields.io/badge/endpoint.svg?&style=flat&logo=github&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-arns-assessment-platform-api)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/hmpps-arns-assessment-platform-api)
 [![Docker Repository on ghcr](https://img.shields.io/badge/ghcr.io-repository-2496ED.svg?logo=docker)](https://ghcr.io/ministryofjustice/hmpps-arns-assessment-platform-api)
-[![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://hmpps-arns-assessment-platform-api-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html?configUrl=/v3/api-docs)
+[![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://arns-assessment-platform-api-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs)
 
 The ARNS Assessment Platform (AAP) API is the backend service for the AAP, providing a unified, event-sourced data
 store for all ARNS assessment types across the justice system. It exposes a CQRS-style interface through command and

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ The system stores four core entity types in PostgreSQL:
 1. Client sends a `POST /command` with a batch of typed commands
 2. The `RetryableCommandDispatcher` dispatches each command through the `CommandBus`
 3. The matched `CommandHandler` validates the command, emits one or more `Event`s, and optionally creates timeline entries
-4. Events are persisted to the `event` table as immutable JSONB records
-5. The `AggregateState` replays events through typed `EventHandler`s to rebuild the `AssessmentAggregate`
+4. The `AggregateState` replays events through typed `EventHandler`s to rebuild associated aggregates (e.g. `AssessmentAggregate`)
+5. Events are persisted to the `event` table as immutable JSONB records
 6. The updated aggregate snapshots are persisted to the `aggregate` table with an incremented version
 7. Audit events are published to SQS
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The system stores four core entity types in PostgreSQL:
 3. The matched `CommandHandler` validates the command, emits one or more `Event`s, and optionally creates timeline entries
 4. Events are persisted to the `event` table as immutable JSONB records
 5. The `AggregateState` replays events through typed `EventHandler`s to rebuild the `AssessmentAggregate`
-6. The updated aggregate snapshot is persisted to the `aggregate` table with an incremented version
+6. The updated aggregate snapshots are persisted to the `aggregate` table with an incremented version
 7. Audit events are published to SQS
 
 ### Read Path (Queries)

--- a/README.md
+++ b/README.md
@@ -1,137 +1,235 @@
-# hmpps-arns-assessment-platform-api
+# HMPPS ARNS Assessment Platform API
 
-[![repo standards badge](https://img.shields.io/badge/endpoint.svg?&style=flat&logo=github&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-arns-assessment-platform-api)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/hmpps-arns-assessment-platform-api "Link to report")
+[![repo standards badge](https://img.shields.io/badge/endpoint.svg?&style=flat&logo=github&url=https%3A%2F%2Foperations-engineering-reports.cloud-platform.service.justice.gov.uk%2Fapi%2Fv1%2Fcompliant_public_repositories%2Fhmpps-arns-assessment-platform-api)](https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/hmpps-arns-assessment-platform-api)
 [![Docker Repository on ghcr](https://img.shields.io/badge/ghcr.io-repository-2496ED.svg?logo=docker)](https://ghcr.io/ministryofjustice/hmpps-arns-assessment-platform-api)
 [![API docs](https://img.shields.io/badge/API_docs_-view-85EA2D.svg?logo=swagger)](https://hmpps-arns-assessment-platform-api-dev.hmpps.service.justice.gov.uk/webjars/swagger-ui/index.html?configUrl=/v3/api-docs)
 
-Template github repo used for new Kotlin based projects.
+The ARNS Assessment Platform (AAP) API is the backend service for the AAP, providing a unified, event-sourced data
+store for all ARNS assessment types across the justice system. It exposes a CQRS-style interface through command and
+query endpoints, with full assessment versioning and an audit timeline.
 
-# Instructions
+## About ARNS Assessment Platform API
 
-If this is a HMPPS project then the project will be created as part of bootstrapping -
-see [dps-project-bootstrap](https://github.com/ministryofjustice/dps-project-bootstrap). You are able to specify a
-template application using the `github_template_repo` attribute to clone without the need to manually do this yourself
-within GitHub.
+The API serves as the single persistent backend for assessment data, built around an event sourcing architecture
+that provides:
 
-This project is community managed by the mojdt `#kotlin-dev` slack channel.
-Please raise any questions or queries there. Contributions welcome!
+- **Event-sourced state management**: Every change to an assessment is captured as an immutable event, enabling
+  full history replay and point-in-time queries
+- **CQRS interface**: Separate command and query endpoints, each accepting batches of typed operations dispatched
+  through dedicated buses
+- **Aggregate-based domain model**: Assessment state is derived by replaying events through typed handlers,
+  with versioned snapshots for read performance
+- **Assessment-agnostic data model**: A generic structure of answers, properties, and collections that supports
+  any assessment type without schema changes
+- **Audit timeline**: Every mutation is recorded with user attribution and timestamps
+
+## Key Technologies
+
+- **Language**: Kotlin
+- **Framework**: Spring Boot 3 with Spring Security (OAuth2 resource server)
+- **Database**: PostgreSQL (Aurora on Cloud Platform) with Flyway migrations
+- **Caching**: Redis for aggregate state caching
+- **Messaging**: SQS via HMPPS SQS library for audit events
+- **Build**: Gradle with Kotlin DSL
+- **Testing**: JUnit 5, Mockito, Testcontainers (PostgreSQL), WireMock
+- **API Documentation**: SpringDoc OpenAPI (Swagger UI)
+
+## Quick Start
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Make
+- JDK 21+ (for local/IntelliJ development)
+
+### Development Setup
+
+The project uses containerised development with all commands available through the Makefile:
+
+```bash
+# Build the development image
+make dev-build
+
+# Start the API with hot-reload (port 8081)
+# Remote debugger available on port 5006
+make dev-up
+
+# Watch for file changes and live-reload
+make dev-up watch
+
+# View all available commands
+make help
+```
+
+The API will be available at http://localhost:8081 with HMPPS Auth on http://localhost:9090
+
+### Running in IntelliJ
+
+Start the supporting services without the API container, then run the Spring Boot application with the `dev` profile:
+
+```bash
+docker compose -f docker/docker-compose.base.yml up postgres redis hmpps-auth localstack --wait
+```
+
+### Common Development Commands
+
+```bash
+# Testing
+make test                         # Run all tests
+make test-targeted TESTS="*Test"  # Run specific tests
+
+# Code Quality
+make lint                         # Run ktlint
+make lint-fix                     # Auto-fix linting issues
+
+# Container Management
+make down                         # Stop all containers
+make clean                        # Clean containers, volumes, and build dirs
+make update                       # Update container images
+
+# Database (requires active kubectl context)
+make db-port-forward-pod          # Create port-forwarding pod
+make db-port-forward              # Forward local port 5434 to remote DB
+make db-connect                   # Connect to remote DB via psql
+
+# TypeScript Client
+make build-client                 # Generate TypeScript client from OpenAPI spec
+```
+
+## Project Structure
+
+```
+hmpps-arns-assessment-platform-api/
+├── src/main/kotlin/.../arnsassessmentplatformapi/
+│   ├── aggregate/              # Aggregate root and event handlers
+│   │   └── assessment/         # AssessmentAggregate and per-event handlers
+│   ├── command/                # Command types and command bus
+│   │   ├── bus/                # CommandBus, retryable dispatcher
+│   │   └── handler/            # One handler per command type
+│   ├── query/                  # Query types and query bus
+│   │   ├── bus/                # QueryBus, handler registry
+│   │   └── handler/            # One handler per query type
+│   ├── event/                  # Event types (sealed interface hierarchy)
+│   │   └── bus/                # Event publishing
+│   ├── controller/             # REST controllers
+│   ├── domain/plan/            # Sentence Plan domain logic
+│   ├── model/                  # Shared domain model (Value, Collection, etc.)
+│   ├── persistence/            # JPA entities, repositories, projections
+│   ├── service/                # Core services (Assessment, Event, Aggregate)
+│   ├── config/                 # Spring configuration, security, exception handling
+│   └── clock/                  # Abstracted clock for testability
+├── src/main/resources/
+│   └── db/migration/           # Flyway SQL migrations
+├── src/test/kotlin/            # Tests (co-located by package)
+├── typescript-client/          # Auto-generated TypeScript API client
+├── docker/                     # Docker Compose files and support scripts
+├── helm_deploy/                # Kubernetes/Helm deployment configs
+└── perf/                       # Performance testing (Gatling)
+```
+
+## Event Sourcing Architecture
+
+### Data Model
+
+The system stores four core entity types in PostgreSQL:
+
+| Table                    | Purpose                                                                       |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `assessment`             | Root entity with UUID and type (e.g. `SENTENCE_PLAN`)                         |
+| `assessment_identifier`  | External identifiers linking assessments to upstream systems (e.g. OASys IDs) |
+| `event`                  | Immutable append-only event log, JSONB payload with polymorphic `data_type`   |
+| `aggregate`              | Versioned snapshots of derived state, rebuilt by replaying events              |
+| `timeline`               | User-facing audit trail entries                                               |
+
+### Write Path (Commands)
+
+1. Client sends a `POST /command` with a batch of typed commands
+2. The `RetryableCommandDispatcher` dispatches each command through the `CommandBus`
+3. The matched `CommandHandler` validates the command, emits one or more `Event`s, and optionally creates timeline entries
+4. Events are persisted to the `event` table as immutable JSONB records
+5. The `AggregateState` replays events through typed `EventHandler`s to rebuild the `AssessmentAggregate`
+6. The updated aggregate snapshot is persisted to the `aggregate` table with an incremented version
+7. Audit events are published to SQS
+
+### Read Path (Queries)
+
+1. Client sends a `POST /query` with a batch of typed queries
+2. The `QueryBus` dispatches each query to its registered `QueryHandler`
+3. Handlers read from aggregate snapshots or the event/timeline stores
+4. Queries accept an optional `timestamp` parameter for point-in-time reads, replaying events up to that moment
+
+### Event Types
+
+Events are a sealed interface hierarchy, polymorphically serialised as JSONB:
+
+- `AssessmentCreatedEvent` / `AssessmentAnswersUpdatedEvent` / `AssessmentPropertiesUpdatedEvent`
+- `CollectionCreatedEvent` / `CollectionItemAddedEvent` / `CollectionItemRemovedEvent` / `CollectionItemReorderedEvent`
+- `CollectionItemAnswersUpdatedEvent` / `CollectionItemPropertiesUpdatedEvent`
+- `AssessmentRolledBackEvent` / `FormVersionUpdatedEvent`
+
+### Command Types
+
+Commands follow the same sealed interface pattern:
+
+- `CreateAssessmentCommand` / `UpdateAssessmentAnswersCommand` / `UpdateAssessmentPropertiesCommand`
+- `CreateCollectionCommand` / `AddCollectionItemCommand` / `RemoveCollectionItemCommand` / `ReorderCollectionItemCommand`
+- `UpdateCollectionItemAnswersCommand` / `UpdateCollectionItemPropertiesCommand`
+- `RollbackCommand` / `SoftDeleteCommand` / `UpdateFormVersionCommand` / `CreateTimelineItemCommand`
+
+### Query Types
+
+- `AssessmentVersionQuery` / `CollectionQuery` / `CollectionItemQuery`
+- `TimelineQuery` / `DailyVersionsQuery`
+- `GetAssessmentsModifiedSinceQuery` / `GetAssessmentsSoftDeletedSinceQuery`
+
+## Testing
+
+### Test Types
+
+#### Unit Tests
+
+JUnit 5 with Mockito for isolated testing of command handlers, event handlers, query handlers, and services.
+
+#### Integration Tests
+
+Testcontainers-based tests that spin up a real PostgreSQL instance to verify repository queries, event replay,
+and aggregate persistence end-to-end.
+
+#### Contract Tests
+
+WireMock-based tests for verifying interactions with external HMPPS services (Auth, etc.).
+
+### Running Tests
+
+```bash
+make test                              # All tests in Docker
+make test-targeted TESTS="*EventTest"  # Specific tests
+./gradlew test                         # Locally (requires running PostgreSQL)
+```
+
+## Deployment
+
+The application is deployed to Cloud Platform environments using GitHub Actions and Helm charts.
+
+### Environments
+
+- **Development** - Continuous deployment from `main` branch
+- **Preprod** - Deployed on successful dev testing
+- **Production** - Manual approval required
+
+### Security Scanning
+
+- Veracode static analysis
+- Trivy container image scanning
+- Gitleaks secret detection
+
+## Contributing
+
+### Code Style
+
+- Kotlin with ktlint enforcement
+- HMPPS Kotlin patterns and conventions
+
+### Security
 
 Our security policy is located [here](https://github.com/ministryofjustice/hmpps-arns-assessment-platform-api/security/policy).
-
-Documentation to create new service is located [here](https://tech-docs.hmpps.service.justice.gov.uk/creating-new-services/).
-
-## Creating a Cloud Platform namespace
-
-When deploying to a new namespace, you may wish to use the
-[templates project namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev)
-as the basis for your new namespace. This namespace contains both the kotlin and typescript template projects, 
-which is the usual way that projects are setup.
-
-Copy this folder and update all the existing namespace references to correspond to the environment to which you're deploying.
-
-If you only need the kotlin configuration then remove all typescript references and remove the elasticache configuration. 
-
-To ensure the correct github teams can approve releases, you will need to make changes to the configuration in `resources/service-account-github` where the appropriate team names will need to be added (based on [lines 98-100](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf#L98) and the reference appended to the teams list below [line 112](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf#L112)). Note: hmpps-sre is in this list to assist with deployment issues.
-
-Submit a PR to the Cloud Platform team in
-#ask-cloud-platform. Further instructions from the Cloud Platform team can be found in
-the [Cloud Platform User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide)
-
-## Renaming from HMPPS Arns Assessment Platform Api - github Actions
-
-Once the new repository is deployed. Navigate to the repository in github, and select the `Actions` tab.
-Click the link to `Enable Actions on this repository`.
-
-Find the Action workflow named: `rename-project-create-pr` and click `Run workflow`. This workflow will
-execute the `rename-project.bash` and create Pull Request for you to review. Review the PR and merge.
-
-Note: ideally this workflow would run automatically however due to a recent change github Actions are not
-enabled by default on newly created repos. There is no way to enable Actions other then to click the button in the UI.
-If this situation changes we will update this project so that the workflow is triggered during the bootstrap project.
-Further reading: <https://github.community/t/workflow-isnt-enabled-in-repos-generated-from-template/136421>
-
-The script takes six arguments:
-
-### New project name
-
-This should start with `hmpps-` e.g. `hmpps-prison-visits` so that it can be easily distinguished in github from
-other departments projects. Try to avoid using abbreviations so that others can understand easily what your project is.
-
-### Slack channel for release notifications
-
-By default, release notifications are only enabled for production. The circleci configuration can be amended to send
-release notifications for deployments to other environments if required. Note that if the configuration is amended,
-the slack channel should then be amended to your own team's channel as `dps-releases` is strictly for production release
-notifications. If the slack channel is set to something other than `dps-releases`, production release notifications
-will still automatically go to `dps-releases` as well. This is configured by `releases-slack-channel` in
-`.circleci/config.yml`.
-
-### Slack channel for pipeline security notifications
-
-Ths channel should be specific to your team and is for daily / weekly security scanning job results. It is your team's
-responsibility to keep up-to-date with security issues and update your application so that these jobs pass. You will
-only be notified if the jobs fail. The scan results can always be found in circleci for your project. This is
-configured by `alerts-slack-channel` in `.circleci/config.yml`.
-
-### Non production kubernetes alerts
-
-By default Prometheus alerts are created in the application namespaces to monitor your application e.g. if your
-application is crash looping, there are a significant number of errors from the ingress. Since Prometheus runs in
-cloud platform AlertManager needs to be setup first with your channel. Please see
-[Create your own custom alerts](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html)
-in the Cloud Platform user guide. Once that is setup then the `custom severity label` can be used for
-`alertSeverity` in the `helm_deploy/values-*.yaml` configuration.
-
-Normally it is worth setting up two separate labels and therefore two separate slack channels - one for your production
-alerts and one for your non-production alerts. Using the same channel can mean that production alerts are sometimes
-lost within non-production issues.
-
-### Production kubernetes alerts
-
-This is the severity label for production, determined by the `custom severity label`. See the above
-#non-production-kubernetes-alerts for more information. This is configured in `helm_deploy/values-prod.yaml`.
-
-### Product ID
-
-This is so that we can link a component to a product and thus provide team and product information in the Developer
-Portal. Refer to the developer portal at https://developer-portal.hmpps.service.justice.gov.uk/products to find your
-product id. This is configured in `helm_deploy/<project_name>/values.yaml`.
-
-## Manually branding from template app
-
-Run the `rename-project.bash` without any arguments. This will prompt for the six required parameters and create a PR.
-The script requires a recent version of `bash` to be installed, as well as GNU `sed` in the path.
-
-## Common Kotlin patterns
-
-Many patterns have evolved for HMPPS Kotlin applications. Using these patterns provides consistency across our suite of 
-Kotlin microservices and allows you to concentrate on building  your business needs rather than reinventing the 
-technical approach.
-
-Documentation for these patterns can be found in the [HMPPS tech docs](https://tech-docs.hmpps.service.justice.gov.uk/common-kotlin-patterns/). 
-If this documentation is incorrect or needs improving please report to [#ask-prisons-digital-sre](https://moj.enterprise.slack.com/archives/C06MWP0UKDE)
-or [raise a PR](https://github.com/ministryofjustice/hmpps-tech-docs). 
-
-## Running the application locally
-
-The application comes with a `dev` spring profile that includes default settings for running locally. This is not
-necessary when deploying to kubernetes as these values are included in the helm configuration templates -
-e.g. `values-dev.yaml`.
-
-There is also a `docker-compose.yml` that can be used to run a local instance of the template in docker and also an
-instance of HMPPS Auth (required if your service calls out to other services using a token).
-
-```bash
-docker compose pull && docker compose up
-```
-
-will build the application and run it and HMPPS Auth within a local docker instance.
-
-### Running the application in Intellij
-
-```bash
-docker compose pull && docker compose up --scale hmpps-arns-assessment-platform-api=0
-```
-
-will just start a docker instance of HMPPS Auth. The application should then be started with a `dev` active profile
-in Intellij.


### PR DESCRIPTION
The README was still the default HMPPS Kotlin template boilerplate with no project-specific content.

- Replaced with a full project overview covering the event sourcing architecture, CQRS command/query bus, data model, write/read paths, and all event/command/query types
- Added quick start, development setup, project structure, testing strategy, and deployment sections
- Styled to match the UI project's README for consistency across the AAP repos